### PR TITLE
Make Writer implement Zap's WriteSyncer

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -138,6 +138,13 @@ func (w *Writer) flush(events []*cloudwatchlogs.InputLogEvent) error {
 	return nil
 }
 
+// implements Zap's WriteSyncer
+// https://godoc.org/go.uber.org/zap/zapcore#WriteSyncer
+// makes it possible to use the writer as Zap's backend directly
+func (w *Writer) Sync() error {
+	return w.Flush()
+}
+
 // buffer splits up b into individual log events and inserts them into the
 // buffer.
 func (w *Writer) buffer(b []byte) (int, error) {


### PR DESCRIPTION
https://godoc.org/go.uber.org/zap/zapcore#WriteSyncer
Makes it possible to use the writer as Zap's backend directly i.e. without having to wrap it like in https://github.com/RedHatInsights/playbook-artifact-validator/blob/f0d43ea357601b5050153d759042aa18042cef4d/utils/logging.go#L89